### PR TITLE
chore: Update jest-webextension-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7093,7 +7093,8 @@
     "jest-webextension-mock": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.7.7.tgz",
-      "integrity": "sha512-iHPzG2+VqR4P06/xQlS8IBuWG51tce8yk0QJ3eZFc8UJpsGmfHEkLxV+NsnlDAdbkGGPevom7LaG9vVBuqghxg=="
+      "integrity": "sha512-iHPzG2+VqR4P06/xQlS8IBuWG51tce8yk0QJ3eZFc8UJpsGmfHEkLxV+NsnlDAdbkGGPevom7LaG9vVBuqghxg==",
+      "dev": true
     },
     "jest-worker": {
       "version": "25.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7091,10 +7091,9 @@
       }
     },
     "jest-webextension-mock": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.5.0.tgz",
-      "integrity": "sha512-qjLFb6vBGDoDaGZjA/A6sDg8D750eVxNb2s3zgD/kwveZGc09PuLmWtMxOD0YSZUTd0xnqBdl8J6rTWijCCpNQ==",
-      "dev": true
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.7.7.tgz",
+      "integrity": "sha512-iHPzG2+VqR4P06/xQlS8IBuWG51tce8yk0QJ3eZFc8UJpsGmfHEkLxV+NsnlDAdbkGGPevom7LaG9vVBuqghxg=="
     },
     "jest-worker": {
       "version": "25.2.6",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,11 @@
     "husky": "^4.2.3",
     "jest": "^25.3.0",
     "jest-fetch-mock": "^3.0.3",
+    "jest-webextension-mock": "^3.7.7",
     "kleur": "^3.0.3",
     "lint-staged": "^10.0.8",
     "prettier": "1.19.1",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"
-  },
-  "dependencies": {
-    "jest-webextension-mock": "^3.7.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,11 +46,13 @@
     "husky": "^4.2.3",
     "jest": "^25.3.0",
     "jest-fetch-mock": "^3.0.3",
-    "jest-webextension-mock": "^3.5.0",
     "kleur": "^3.0.3",
     "lint-staged": "^10.0.8",
     "prettier": "1.19.1",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"
+  },
+  "dependencies": {
+    "jest-webextension-mock": "^3.7.7"
   }
 }

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,16 +1,5 @@
 require('jest-fetch-mock').enableMocks();
 require('jest-webextension-mock');
 
-// `jest-webextension-mock` missed mocking a few web extensions APIs
-chrome.webNavigation = {
-  onCompleted: {
-    addListener: jest.fn(),
-  },
-  onHistoryStateUpdated: {
-    addListener: jest.fn(),
-  },
-};
-chrome.runtime.openOptionsPage = jest.fn();
-
 document.addEventListener = jest.fn();
 window.alert = jest.fn();


### PR DESCRIPTION
### Overview

This project is really great! I noticed that in the unit testing some of the custom mocks are no longer needed as jest-webextension-mock now supports them. The pull request increases the version to take advantage of the updates mocks available.

### Changes

* Update jest-webextension-mock from `v3.5` to `v3.7.7`
* Removed custom web extension API mocks from `setupJest.js`