### PR TITLE
fix: update branch-name extracting logic

### DIFF
--- a/src/content-script.js
+++ b/src/content-script.js
@@ -32,7 +32,21 @@ function createLinkElement(label, href, isEnvReachable) {
 }
 
 function extractBranchName(element) {
-  return element.firstChild.textContent;
+  // Received element structure
+  // <div data-qa="pr-branches-and-state-styles">
+  //   <div>
+  //     <div>
+  //       <span><span>Branch: ${branchName}</span></span>
+  //       <div><span>${branchName}</span></div>
+  //     </div>
+  //   </div>
+  //   <div>...</div>
+  //   <div>...</div>
+  // </div>
+
+  return Array.from(element.firstChild.querySelectorAll('span'))
+    .map(ele => ele.textContent)
+    .pop();
 }
 
 function appendLink(linkElement) {
@@ -46,6 +60,9 @@ function appendLink(linkElement) {
 
 async function addTestEnvLinkToThePage(branchNameElement, linkLabel, linkHref) {
   const branchName = extractBranchName(branchNameElement);
+  logger.debug(`Branch Name: ${branchName}`);
+  logger.debug(`Test environment domain: ${linkHref}`);
+
   const testEnvURL = getTestEnvURL(branchName, linkHref);
   logger.debug(`Test environment URL: ${testEnvURL}`);
 

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -20,16 +20,46 @@ exports.setupForm = function() {
   };
 };
 
+function getElement(type, text = null, children = null) {
+  const ele = document.createElement(type);
+  if (text) ele.innerHTML = text;
+  if (children) children.forEach(child => ele.appendChild(child));
+
+  return ele;
+}
+
 exports.getBranchNameElement = function(branchName = '') {
-  const ele = document.createElement('span');
+  // Should return the following structure
+  // <div data-qa="pr-branches-and-state-styles">
+  //   <div>
+  //     <div>
+  //       <span><span>Branch: ${branchName}</span></span>
+  //       <div><span>${branchName}</span></div>
+  //     </div>
+  //   </div>
+  //   <div>...</div>
+  //   <div>...</div>
+  // </div>
+
+  const ele = getElement('div');
   ele.setAttribute('data-qa', 'pr-branches-and-state-styles');
-  ele.textContent = branchName;
+
+  const branchNameEle = getElement('div', null, [
+    getElement('div', null, [
+      getElement('span', null, [getElement('span', `Branch: ${branchName}`)]),
+      getElement('div', null, [getElement('span', branchName)]),
+    ]),
+  ]);
+
+  ele.appendChild(branchNameEle);
+  ele.appendChild(getElement('div'));
+  ele.appendChild(getElement('div'));
 
   return ele;
 };
 
 exports.mockConsole = function() {
-  console.error = jest.spyOn(console, 'log').mockImplementation(() => {});
+  console.error = jest.spyOn(console, 'error').mockImplementation(() => {});
   console.debug = jest.spyOn(console, 'debug').mockImplementation(() => {});
   console.log = jest.spyOn(console, 'log').mockImplementation(() => {});
 };


### PR DESCRIPTION
Issue
The Bitbucket pull request page's branch-name element structure has changed.
So the branch-name extracting function has been returning an invalid branch name.
Therefore, the link is not getting added to the page.

Solution
Branch-name extracting logic has been updated to handle
pull request page's branch-name element structure changes.

Todo: Investigate adding a monitoring system for the extension
https://docs.datadoghq.com/logs/log_collection/javascript/